### PR TITLE
toggle player by pressing space

### DIFF
--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -55,8 +55,21 @@ class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldDelegat
     
     downloadsButton.view?.isHidden = true
     Library.global.downloadManager.delegate = self
+
+    NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+      self.keyDown(with: $0)
+      return $0
+    }
   }
-  
+
+  override func keyDown(with event: NSEvent) {
+    if event.characters == " " {
+      Player.global.togglePlay();
+    } else {
+      super.keyDown(with: event);
+    }
+  }
+
   // Subscribed to Search input changes
   override func controlTextDidChange(_ obj: Notification) {
     if searchInputView.stringValue.characters.count > 0 {


### PR DESCRIPTION
Minor thing but I found it useful, hence, sharing it.

P.S. Thanks for the work on the app.

~NOTE: please be aware that this change breaks the cmd+left and cmd+right bindings for forward/backward functionality. Hence, it is not a good idea to merge this. I just wanted to share the changes in case someone else was looking for the same.~