### PR TITLE
Enforce the code style to avoid 'get' for readonly computed properties.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,5 @@
-# https://github.com/airbnb/swift
+# This file is based on the Airbnb's Swift Style Guide
+# https://github.com/airbnb/swift/blob/master/Sources/AirbnbSwiftFormatTool/swiftlint.yml
 
 only_rules:
   - closure_spacing
@@ -7,11 +8,9 @@ only_rules:
   - extension_access_modifier
   - fatal_error_message
   - file_header
-  # - force_cast
   - force_try
-  # - force_unwrapping
-  # - implicitly_unwrapped_optional
   - generic_type_name
+  - implicit_getter
   - legacy_cggeometry_functions
   - legacy_constant
   - legacy_constructor

--- a/Doughnut/Library/Episode.swift
+++ b/Doughnut/Library/Episode.swift
@@ -47,10 +47,8 @@ class Episode: Record {
   var downloading: Bool = false
 
   var plainDescription: String? {
-    get {
-      guard let description = description else { return nil }
-      return description.replacingOccurrences(of: "<[^>]+>", with: "", options: String.CompareOptions.regularExpression, range: nil).trimmingCharacters(in: .whitespacesAndNewlines)
-    }
+    guard let description = description else { return nil }
+    return description.replacingOccurrences(of: "<[^>]+>", with: "", options: String.CompareOptions.regularExpression, range: nil).trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   override class var databaseTableName: String {

--- a/Doughnut/Library/Library.swift
+++ b/Doughnut/Library/Library.swift
@@ -72,10 +72,8 @@ class Library: NSObject {
   var podcasts = [Podcast]()
 
   var unplayedCount: Int {
-    get {
-      return podcasts.reduce(0) {
-        $0 + $1.unplayedCount
-      }
+    return podcasts.reduce(0) {
+      $0 + $1.unplayedCount
     }
   }
 

--- a/Doughnut/Library/Podcast.swift
+++ b/Doughnut/Library/Podcast.swift
@@ -46,44 +46,34 @@ class Podcast: Record {
   private(set) var image: NSImage?
 
   var manualReload: Bool {
-    get {
-      return reloadFrequency == -1
-    }
+    return reloadFrequency == -1
   }
 
   var defaultReload: Bool {
-    get {
-      return reloadFrequency == 0
-    }
+    return reloadFrequency == 0
   }
 
   var episodes = [Episode]()
 
   var unplayedCount: Int {
-    get {
-      return episodes.reduce(0) {
-        $0 + ($1.played == false ? 1 : 0)
-      }
+    return episodes.reduce(0) {
+      $0 + ($1.played == false ? 1 : 0)
     }
   }
 
   var favouriteCount: Int {
-    get {
-      return episodes.reduce(0) {
-        $0 + ($1.favourite ? 1 : 0)
-      }
+    return episodes.reduce(0) {
+      $0 + ($1.favourite ? 1 : 0)
     }
   }
 
   var latestEpisode: Episode? {
-    get {
-      return episodes.sorted(by: { (a, b) -> Bool in
-        guard let aD = a.pubDate else { return false }
-        guard let bD = b.pubDate else { return true }
+    return episodes.sorted(by: { (a, b) -> Bool in
+      guard let aD = a.pubDate else { return false }
+      guard let bD = b.pubDate else { return true }
 
-        return aD < bD
-      }).last
-    }
+      return aD < bD
+    }).last
   }
 
   var loading = false

--- a/Doughnut/Player/Player.swift
+++ b/Doughnut/Player/Player.swift
@@ -69,17 +69,13 @@ final class Player: NSObject {
   }
 
   var isPlaying: Bool {
-    get {
-      guard let av = avPlayer else { return false }
-      return av.rate != 0 && av.error == nil
-    }
+    guard let av = avPlayer else { return false }
+    return av.rate != 0 && av.error == nil
   }
 
   var canPlay: Bool {
-    get {
-      guard let av = avPlayer else { return false }
-      return av.error == nil
-    }
+    guard let av = avPlayer else { return false }
+    return av.error == nil
   }
 
   var nowPlayingEpisodeInfoDictionary = [String: Any]()

--- a/Doughnut/Preference/PrefGeneralViewController.swift
+++ b/Doughnut/Preference/PrefGeneralViewController.swift
@@ -30,20 +30,16 @@ final class PrefGeneralViewController: NSViewController, MASPreferencesViewContr
   @objc var viewIdentifier: String = "PrefGeneralViewController"
 
   @objc var toolbarItemImage: NSImage? {
-    get {
-      if #available(macOS 11.0, *) {
-        return NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)!
-      } else {
-        return NSImage(named: NSImage.preferencesGeneralName)
-      }
+    if #available(macOS 11.0, *) {
+      return NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)!
+    } else {
+      return NSImage(named: NSImage.preferencesGeneralName)
     }
   }
 
   @objc var toolbarItemLabel: String? {
-    get {
-      view.layoutSubtreeIfNeeded()
-      return "General"
-    }
+    view.layoutSubtreeIfNeeded()
+    return "General"
   }
 
   override func viewDidLoad() {

--- a/Doughnut/Preference/PrefLibraryViewController.swift
+++ b/Doughnut/Preference/PrefLibraryViewController.swift
@@ -30,20 +30,16 @@ final class PrefLibraryViewController: NSViewController, MASPreferencesViewContr
   @objc var viewIdentifier: String = "PrefLibraryViewController"
 
   @objc var toolbarItemImage: NSImage? {
-    get {
-      if #available(macOS 11.0, *) {
-        return NSImage(systemSymbolName: "square.stack", accessibilityDescription: nil)!
-      } else {
-        return NSImage(named: "PrefIcon/Library")!
-      }
+    if #available(macOS 11.0, *) {
+      return NSImage(systemSymbolName: "square.stack", accessibilityDescription: nil)!
+    } else {
+      return NSImage(named: "PrefIcon/Library")!
     }
   }
 
   @objc var toolbarItemLabel: String? {
-    get {
-      view.layoutSubtreeIfNeeded()
-      return "Library"
-    }
+    view.layoutSubtreeIfNeeded()
+    return "Library"
   }
 
   override func viewDidAppear() {

--- a/Doughnut/Preference/PrefPlaybackViewController.swift
+++ b/Doughnut/Preference/PrefPlaybackViewController.swift
@@ -30,20 +30,16 @@ final class PrefPlaybackViewController: NSViewController, MASPreferencesViewCont
   @objc var viewIdentifier: String = "PrefPlaybackViewController"
 
   @objc var toolbarItemImage: NSImage? {
-    get {
-      if #available(macOS 11.0, *) {
-        return NSImage(systemSymbolName: "play.circle", accessibilityDescription: nil)!
-      } else {
-        return NSImage(named: "PrefIcon/Playback")
-      }
+    if #available(macOS 11.0, *) {
+      return NSImage(systemSymbolName: "play.circle", accessibilityDescription: nil)!
+    } else {
+      return NSImage(named: "PrefIcon/Playback")
     }
   }
 
   @objc var toolbarItemLabel: String? {
-    get {
-      view.layoutSubtreeIfNeeded()
-      return "Playback"
-    }
+    view.layoutSubtreeIfNeeded()
+    return "Playback"
   }
 
   @objc var hasResizableWidth: Bool = false

--- a/Doughnut/Preference/Preference.swift
+++ b/Doughnut/Preference/Preference.swift
@@ -67,9 +67,7 @@ class Preference {
   static let kVolume = "Volume"
 
   static var defaultLibraryPath: URL {
-    get {
-      return Preference.userMusicPath().appendingPathComponent("Doughnut")
-    }
+    return Preference.userMusicPath().appendingPathComponent("Doughnut")
   }
 
   static let defaultPreference: [String: Any] = [

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -76,9 +76,7 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
   }
 
   var viewController: ViewController {
-    get {
-      return parent as! ViewController
-    }
+    return parent as! ViewController
   }
 
   override func viewDidLoad() {

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -78,9 +78,7 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
   }
 
   var viewController: ViewController {
-    get {
-      return parent as! ViewController
-    }
+    return parent as! ViewController
   }
 
   override func viewDidLoad() {

--- a/Doughnut/View Controllers/TasksViewController.swift
+++ b/Doughnut/View Controllers/TasksViewController.swift
@@ -69,9 +69,7 @@ class TaskView: NSView, TaskProgressDelegate {
   }
 
   override var intrinsicContentSize: NSSize {
-    get {
-      return NSSize(width: bounds.size.width, height: TASK_VIEW_HEIGHT)
-    }
+    return NSSize(width: bounds.size.width, height: TASK_VIEW_HEIGHT)
   }
 
   func progressed() {

--- a/Doughnut/View Controllers/ViewController.swift
+++ b/Doughnut/View Controllers/ViewController.swift
@@ -31,21 +31,15 @@ final class ViewController: NSSplitViewController, LibraryDelegate {
   }
 
   var podcastViewController: PodcastViewController {
-    get {
-      return splitViewItems[0].viewController as! PodcastViewController
-    }
+    return splitViewItems[0].viewController as! PodcastViewController
   }
 
   var episodeViewController: EpisodeViewController {
-    get {
-      return splitViewItems[1].viewController as! EpisodeViewController
-    }
+    return splitViewItems[1].viewController as! EpisodeViewController
   }
 
   var detailViewController: DetailViewController {
-    get {
-      return splitViewItems[2].viewController as! DetailViewController
-    }
+    return splitViewItems[2].viewController as! DetailViewController
   }
 
   override func viewDidLoad() {

--- a/Doughnut/Views/SeekSlider.swift
+++ b/Doughnut/Views/SeekSlider.swift
@@ -26,9 +26,7 @@ final class SeekSlider: NSSlider {
    }
 
   override var knobThickness: CGFloat {
-    get {
-      return 3.0
-    }
+    return 3.0
   }
 
   var streamedValue: Double = 0 {
@@ -66,22 +64,18 @@ private class SeekSliderCell: NSSliderCell {
   }
 
   var percentage: CGFloat {
-    get {
-      if (self.maxValue - self.minValue) > 0 {
-        return CGFloat((self.doubleValue - self.minValue) / (self.maxValue - self.minValue))
-      } else {
-        return 0
-      }
+    if (self.maxValue - self.minValue) > 0 {
+      return CGFloat((self.doubleValue - self.minValue) / (self.maxValue - self.minValue))
+    } else {
+      return 0
     }
   }
 
   var streamedPercentage: CGFloat {
-    get {
-      if (self.maxValue - self.minValue) > 0 {
-        return CGFloat((self.streamed - self.minValue) / (self.maxValue - self.minValue))
-      } else {
-        return 0
-      }
+    if (self.maxValue - self.minValue) > 0 {
+      return CGFloat((self.streamed - self.minValue) / (self.maxValue - self.minValue))
+    } else {
+      return 0
     }
   }
 

--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -29,9 +29,7 @@ final class WindowController: NSWindowController, NSTextFieldDelegate {
   }
 
   var subscribeViewController: SubscribeViewController {
-    get {
-      return self.storyboard!.instantiateController(withIdentifier: "SubscribeViewController") as! SubscribeViewController
-    }
+    return self.storyboard!.instantiateController(withIdentifier: "SubscribeViewController") as! SubscribeViewController
   }
 
   override func windowDidLoad() {

--- a/Doughnut/Windows/ShowEpisodeWindow.swift
+++ b/Doughnut/Windows/ShowEpisodeWindow.swift
@@ -40,9 +40,7 @@ final class ShowEpisodeWindowController: NSWindowController {
 
 class ShowEpisodeWindow: NSWindow {
   override var canBecomeKey: Bool {
-    get {
-      return true
-    }
+    return true
   }
 }
 

--- a/Doughnut/Windows/ShowPodcastWindow.swift
+++ b/Doughnut/Windows/ShowPodcastWindow.swift
@@ -40,9 +40,7 @@ final class ShowPodcastWindowController: NSWindowController {
 
 class ShowPodcastWindow: NSWindow {
   override var canBecomeKey: Bool {
-    get {
-      return true
-    }
+    return true
   }
 }
 


### PR DESCRIPTION
This PR removes the redundant `get` keyword for readonly computed properties and enforce the `implicit_getter` rule for SwiftLint.